### PR TITLE
Add support for generating GXPES compatible binaries.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,5 +56,6 @@ build
 .vscode
 
 piglet_stub/out
+shacc_stub/out
 combine
 samples/cube-glfw-back

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ else
 endif
 
 LIB     = pib
-OBJS    = src/pib.o src/hooks.o src/shacccgpatch.o src/patches.o src/sha1.o src/sysmodepatch.o
+OBJS    = src/pib.o src/hooks.o src/shacccgpatch.o src/patches.o src/sha1.o src/sysmodepatch.o src/essl.o
 INCLUDE = include
 
 PREFIX ?= $(SDKPATH)/arm-$(SDKPREFIX)-eabi
@@ -39,16 +39,20 @@ endif
 
 lib: lib$(LIB).a
 
-stub: piglet_stub/out/liblibScePiglet_stub.a
+stub: piglet_stub/out/liblibScePiglet_stub.a shacc_stub/out/libSceShaccCg_stub.a
 
 piglet_stub/out/liblibScePiglet_stub.a:
 	$(MAKE) -C piglet_stub SDKPREFIX=$(SDKPREFIX)
+
+shacc_stub/out/libSceShaccCg_stub.a:
+	$(MAKE) -C shacc_stub SDKPREFIX=$(SDKPREFIX)
 
 %.a: $(OBJS) 
 	$(AR) -rc $@ $^
 
 clean:
 	@$(MAKE) -C piglet_stub clean
+	@$(MAKE) -C shacc_stub clean
 	@rm -rf combine $(OBJS) lib$(LIB).a
 
 install: lib$(LIB).a
@@ -70,8 +74,9 @@ ifeq ($(USE_VITASDK),1)
 install: install_stub
 endif
 
-install_stub: piglet_stub/out/liblibScePiglet_stub.a
+install_stub: piglet_stub/out/liblibScePiglet_stub.a shacc_stub/out/libSceShaccCg_stub.a
 	@mkdir -p $(DESTDIR)$(PREFIX)/lib/
 	@cp piglet_stub/out/liblibScePiglet_stub.a $(DESTDIR)$(PREFIX)/lib/
+	@cp shacc_stub/out/libSceShaccCg_stub.a $(DESTDIR)$(PREFIX)/lib/
 
 .PHONY: install install_stub clean

--- a/include/essl.h
+++ b/include/essl.h
@@ -117,6 +117,6 @@ typedef struct SceShaccCgCompileOutput SceShaccCgCompileOutput; // Forward decla
  * @param binary Pointer to pass the GXPES binary to.
  * @param binarySize Size of the output binary
  */
-void EsslCreateBinary(SceShaccCgCompileOutput *compileOutput, void **binary, size_t *binarySize, int vertexShader);
+void EsslCreateBinary(const SceShaccCgCompileOutput *compileOutput, void **binary, size_t *binarySize, int vertexShader);
 
 #endif /* ESSL_H_ */

--- a/include/essl.h
+++ b/include/essl.h
@@ -1,0 +1,122 @@
+#ifndef ESSL_H_
+#define ESSL_H_
+
+#include <stdint.h>
+#include <stddef.h>
+
+/**
+ * @brief GXPES file header
+ * 
+ */
+typedef struct __attribute__((__packed__)) EsslHeader
+{
+    char magic[6]; //!< "GXPES\0"
+    uint32_t parameterTableOffset;
+    uint32_t parameterTableSize;
+} EsslHeader;
+
+/**
+ * @brief ESSL Parameter Formats.
+ * 
+ */
+typedef enum EsslParameterFormat 
+{
+    ESSL_PARAMETER_FORMAT_BOOL,
+    ESSL_PARAMETER_FORMAT_BVEC2,
+    ESSL_PARAMETER_FORMAT_BVEC3,
+    ESSL_PARAMETER_FORMAT_BVEC4,
+    ESSL_PARAMETER_FORMAT_INT,
+    ESSL_PARAMETER_FORMAT_IVEC2,
+    ESSL_PARAMETER_FORMAT_IVEC3,
+    ESSL_PARAMETER_FORMAT_IVEC4,
+    ESSL_PARAMETER_FORMAT_FLOAT,
+    ESSL_PARAMETER_FORMAT_VEC2,
+    ESSL_PARAMETER_FORMAT_VEC3,
+    ESSL_PARAMETER_FORMAT_VEC4,
+    ESSL_PARAMETER_FORMAT_MAT2,
+    ESSL_PARAMETER_FORMAT_MAT3,
+    ESSL_PARAMETER_FORMAT_MAT4,
+    ESSL_PARAMETER_FORMAT_SAMPLER2D,
+    ESSL_PARAMETER_FORMAT_SAMPLERCUBE
+} EsslParameterFormat;
+
+/**
+ * @brief ESSL Parameter types
+ * 
+ */
+typedef enum EsslParameterType 
+{
+    ESSL_PARAMETER_TYPE_ATTRIBUTE,      //!< Vertex attribute input data.
+    ESSL_PARAMETER_TYPE_UNIFORM,        //!< Uniform input data.
+    ESSL_PARAMETER_TYPE_VARYING_INPUT,  //!< Varying input data.
+    ESSL_PARAMETER_TYPE_VARYING_OUTPUT, //!< Varying output data.
+} EsslParameterType;
+
+/**
+ * @brief ESSL Parameter States.
+ * 
+ */
+typedef enum EsslParameterState
+{
+    ESSL_PARAMETER_STATE_INACTIVE, //!< The parameter is not referenced in the shader.
+    ESSL_PARAMETER_STATE_ACTIVE    //!< The parameter is referenced in the shader.
+} EsslParameterState;
+
+/**
+ * @brief Special Varying types.
+ */
+typedef enum EsslVaryingType
+{
+    ESSL_VARYING_TYPE_TEXCOORD,   //!< User-defined varying
+    ESSL_VARYING_TYPE_POSITION,   //!< gl_Position
+    ESSL_VARYING_TYPE_POINTSIZE,  //!< gl_PointSize
+    ESSL_VARYING_TYPE_FRAGCOORD,  //!< gl_FragCoord
+    ESSL_VARYING_TYPE_FRONTFACE,  //!< gl_FrontFacing
+    ESSL_VARYING_TYPE_POINTCOORD, //!< gl_PointCoord
+    ESSL_VARYING_TYPE_FRAGCOLOR   //!< gl_FragColor
+} EsslVaryingType;
+
+/**
+ * @brief An ESSL shader parameter
+ * 
+ */
+typedef struct EsslParameter 
+{
+    union 
+    {
+        uint32_t parameterNameOffset; //!< Offset to parameter name from the parameter
+        char *parameterName;
+    };
+
+    uint32_t state;        //!< One of ::EsslParameterState
+    uint32_t type;         //!< One of ::EsslParameterType
+    uint32_t elementCount; //!< Number of Array elements
+    uint32_t format;       //!< One of ::EsslParameterFormat
+} EsslParameter;
+
+/**
+ * @brief An ESSL shader varying.
+ * 
+ */
+typedef struct EsslVaryingParameter
+{
+    EsslParameter header;
+
+    uint32_t varyingType;   //!< One of ::EsslVaryingType.
+    uint32_t resourceIndex; //!< The resource index. Will be 0xFF for inactive parameters.
+    
+    char padding[0x24];
+} EsslVaryingParameter;
+
+typedef struct SceShaccCgCompileOutput SceShaccCgCompileOutput; // Forward declaration.
+
+/**
+ * @brief Create ESSL/GXPES binary from ShaccCg compile output.
+ *
+ * @param compileOutput ShaccCg compile output
+ * @param binary Pointer to pass the GXPES binary to.
+ * @param binarySize Size of the output binary
+ */
+void EsslCreateBinary(SceShaccCgCompileOutput *compileOutput, void **binary, size_t *binarySize, int vertexShader);
+
+#endif /* ESSL_H_ */

--- a/include/shacccg/paramquery.h
+++ b/include/shacccg/paramquery.h
@@ -1,0 +1,527 @@
+#ifndef _DOLCESDK_PSP2_SHACCCG_PARAMQUERY_H_
+#define _DOLCESDK_PSP2_SHACCCG_PARAMQUERY_H_
+
+#include <stdint.h>
+
+#ifdef	__cplusplus
+extern "C" {
+#endif	// def __cplusplus
+
+///////////////////////////////////////////////////////////////////////////////
+// Forward declarations
+///////////////////////////////////////////////////////////////////////////////
+typedef void const * SceShaccCgParameter;
+typedef struct SceShaccCgCompileOutput SceShaccCgCompileOutput;
+
+///////////////////////////////////////////////////////////////////////////////
+// Constants
+///////////////////////////////////////////////////////////////////////////////
+
+/** @brief	Classifies shader parameter class
+
+	@ingroup shacccg
+*/
+typedef enum SceShaccCgParameterClass {
+	SCE_SHACCCG_PARAMETERCLASS_INVALID		= 0x00,	///< An invalid parameter class.
+	SCE_SHACCCG_PARAMETERCLASS_SCALAR		= 0x01,	///< Scalar parameter class.
+	SCE_SHACCCG_PARAMETERCLASS_VECTOR		= 0x02,	///< Vector parameter class.
+	SCE_SHACCCG_PARAMETERCLASS_MATRIX		= 0x03,	///< Matrix parameter class.
+	SCE_SHACCCG_PARAMETERCLASS_STRUCT		= 0x04,	///< Struct parameter class.
+	SCE_SHACCCG_PARAMETERCLASS_ARRAY		= 0x05,	///< Array parameter class.
+	SCE_SHACCCG_PARAMETERCLASS_SAMPLER		= 0x06,	///< Sampler parameter class.
+	SCE_SHACCCG_PARAMETERCLASS_UNIFORMBLOCK	= 0x07	///< Uniform Block parameter class.
+} SceShaccCgParameterClass;
+
+/** @brief	Classifies shader parameter data format
+
+	@ingroup shacccg
+*/
+typedef enum SceShaccCgParameterBaseType {
+	SCE_SHACCCG_BASETYPE_INVALID		= 0x00,		///< An invalid format.
+	SCE_SHACCCG_BASETYPE_FLOAT			= 0x01,		///< Full precision 32-bit floating point.
+	SCE_SHACCCG_BASETYPE_HALF			= 0x02,		///< Half precision 16-bit floating point.
+	SCE_SHACCCG_BASETYPE_FIXED			= 0x03,		///< 2.8 fixed point precision.
+	SCE_SHACCCG_BASETYPE_BOOL			= 0x04,		///< Boolean value.
+	SCE_SHACCCG_BASETYPE_CHAR			= 0x05,		///< Signed char (8-bit) value.
+	SCE_SHACCCG_BASETYPE_UCHAR			= 0x06,		///< Unsigned char (8-bit) value.
+	SCE_SHACCCG_BASETYPE_SHORT			= 0x07,		///< Signed short (16-bit) value.
+	SCE_SHACCCG_BASETYPE_USHORT			= 0x08,		///< Unsigned short (16-bit) value.
+	SCE_SHACCCG_BASETYPE_INT			= 0x09,		///< Signed int (32-bit) value.
+	SCE_SHACCCG_BASETYPE_UINT			= 0x0a,		///< Unsigned int (32-bit) value.
+	SCE_SHACCCG_BASETYPE_SAMPLER1D		= 0x0b,		///< 1D sampler
+	SCE_SHACCCG_BASETYPE_ISAMPLER1D		= 0x0c,		///< 1D signed integer sampler
+	SCE_SHACCCG_BASETYPE_USAMPLER1D		= 0x0d,		///< 1D unsigned integer sampler
+	SCE_SHACCCG_BASETYPE_SAMPLER2D		= 0x0e,		///< 2D sampler
+	SCE_SHACCCG_BASETYPE_ISAMPLER2D		= 0x0f,		///< 2D signed integer sampler
+	SCE_SHACCCG_BASETYPE_USAMPLER2D		= 0x10,		///< 2D unsigned integer sampler
+	SCE_SHACCCG_BASETYPE_SAMPLERCUBE	= 0x11,		///< Cube sampler
+	SCE_SHACCCG_BASETYPE_ISAMPLERCUBE	= 0x12,		///< Cube signed integer sampler
+	SCE_SHACCCG_BASETYPE_USAMPLERCUBE	= 0x13,		///< Cube unsigned integer sampler
+	SCE_SHACCCG_BASETYPE_ARRAY			= 0x17,		///< An array
+	SCE_SHACCCG_BASETYPE_STRUCT			= 0x18,		///< A structure
+	SCE_SHACCCG_BASETYPE_UNIFORMBLOCK	= 0x19		///< A uniform block
+} SceShaccCgParameterBaseType;
+
+
+///////////////////////////////////////////////////////////////////////////////
+// Structs
+///////////////////////////////////////////////////////////////////////////////
+
+/** @brief	Classifies matrix memory layout
+
+	@ingroup shacccg
+*/
+typedef enum SceShaccCgParameterMemoryLayout
+{
+	SCE_SHACCCG_MEMORYLAYOUT_INVALID,				///< Invalid memory layout
+	SCE_SHACCCG_MEMORYLAYOUT_COLUMN_MAJOR,			///< Column major memory layout
+	SCE_SHACCCG_MEMORYLAYOUT_ROW_MAJOR				///< Row major memory layout
+} SceShaccCgParameterMemoryLayout;
+
+/** @brief	Classifies shader parameter variability
+
+	@ingroup shacccg
+*/
+typedef enum SceShaccCgParameterVariability
+{
+	SCE_SHACCCG_VARIABILITY_INVALID,				///< Invalid variability
+	SCE_SHACCCG_VARIABILITY_VARYING,				///< Parameter is varying
+	SCE_SHACCCG_VARIABILITY_UNIFORM					///< Parameter is uniform
+} SceShaccCgParameterVariability;
+
+/** @brief	Classifies shader parameter direction
+
+	@ingroup shacccg
+*/
+typedef enum SceShaccCgParameterDirection
+{
+	SCE_SHACCCG_DIRECTION_INVALID,					///< Invalid direction
+	SCE_SHACCCG_DIRECTION_IN,						///< Parameter is input
+	SCE_SHACCCG_DIRECTION_OUT						///< Parameter is output
+} SceShaccCgParameterDirection;
+
+
+///////////////////////////////////////////////////////////////////////////////
+// Functions
+///////////////////////////////////////////////////////////////////////////////
+
+/**	@brief	Start parameter enumeration.
+
+	Start parameter enumeration.
+
+	@param[in] prog
+		The output of a successful shader compilation.
+
+	@return
+		A SceShaccCgParameter object representing the first parameter in the shader.
+		If 0 is returned, the input argument was malformed or the shader has no public
+		symbols.
+
+	@ingroup shacccg
+*/
+SceShaccCgParameter sceShaccCgGetFirstParameter(
+	SceShaccCgCompileOutput const* prog);
+
+/**	@brief	Access the next parameter in the global list of shader parameter.
+
+	Access the next parameter in the global list of shader parameter.
+
+	@param[in] param
+		The current parameter object.
+
+	@return
+		A SceShaccCgParameter object representing the next parameter, or NULL if there are
+		no more parameters.
+
+	@ingroup shacccg
+*/
+SceShaccCgParameter sceShaccCgGetNextParameter(
+	SceShaccCgParameter param);
+
+/**	@brief	Find a parameter by its name.
+
+	Find a parameter by its name.
+
+	@param[in] prog
+		The output of a successful shader compilation.
+
+	@param[in] name
+		The name of the parameter.
+
+	@return
+		A SceShaccCgParameter object representing the parameter or NULL if the
+		parameter was not found.
+
+	@ingroup shacccg
+*/
+SceShaccCgParameter sceShaccCgGetParameterByName(
+	SceShaccCgCompileOutput const* prog,
+	char const *name);
+
+/**	@brief	Returns the name of a parameter.
+
+	Returns the name of a parameter.
+
+	@param[in] param
+		The parameter object.
+
+	@return
+		A NULL terminated string containing the name of the parameter
+
+	@ingroup shacccg
+*/
+const char * sceShaccCgGetParameterName(
+	SceShaccCgParameter param);
+
+/**	@brief	Returns the semantic of a parameter.
+
+	Returns the semantic of a parameter.
+
+	@param[in] param
+		The parameter object.
+
+	@return
+		A NULL terminated string containing the semantic of the parameter or NULL
+		if no semantic was declared
+
+	@ingroup shacccg
+*/
+const char * sceShaccCgGetParameterSemantic(
+	SceShaccCgParameter param);
+
+/**	@brief	Returns the user declared type of a parameter.
+
+	Returns the user declared type of a parameter.
+
+	@param[in] param
+		The parameter object.
+
+	@return
+		A NULL terminated string containing the user declared type of the parameter or NULL
+		if no user declared type was used
+
+	@ingroup shacccg
+*/
+const char * sceShaccCgGetParameterUserType(
+	SceShaccCgParameter param);
+
+/**	@brief	Returns the parameter class.
+
+	Returns the parameter class.
+
+	@param[in] param
+		The parameter object.
+
+	@return
+		The SceShaccCgParameterClass value this parameter is part of.
+
+	@ingroup shacccg
+*/
+SceShaccCgParameterClass sceShaccCgGetParameterClass(
+	SceShaccCgParameter param);
+
+/**	@brief	Returns the parameter variability.
+
+	Returns the parameter variability.
+
+	@param[in] param
+		The parameter object.
+
+	@return
+		The SceShaccCgParameterVariability value for the parameter.
+
+	@ingroup shacccg
+*/
+SceShaccCgParameterVariability sceShaccCgGetParameterVariability(
+	SceShaccCgParameter param);
+
+/**	@brief	Returns the parameter direction.
+
+	Returns the parameter direction.
+
+	@param[in] param
+		The parameter object.
+
+	@return
+		The SceShaccCgParameterDirection value for the parameter.
+
+	@ingroup shacccg
+*/
+SceShaccCgParameterDirection sceShaccCgGetParameterDirection(
+	SceShaccCgParameter param);
+
+/**	@brief	Returns the parameter base type.
+
+	Returns the parameter base type.
+
+	@param[in] param
+		The parameter object.
+
+	@return
+		The SceShaccCgParameterBaseType value for the parameter.
+
+	@ingroup shacccg
+*/
+SceShaccCgParameterBaseType sceShaccCgGetParameterBaseType(
+	SceShaccCgParameter param);
+
+/**	@brief	Returns true if the parameter is referenced.
+
+	Returns true if the parameter is referenced.
+
+	@param[in] param
+		The parameter object.
+
+	@return
+		1 if the value is referenced, otherwise return 0 if the parameter is dead.
+
+	@ingroup shacccg
+*/
+int32_t sceShaccCgIsParameterReferenced(
+	SceShaccCgParameter param);
+
+/**	@brief	Returns the hw resource index of the parameter.
+
+	Returns the hw resource index of the parameter.
+
+	@param[in] param
+		The parameter object.
+
+	@return
+		The resource index or a value of -1 if no resource is assigned to this parameter.
+
+	@ingroup shacccg
+*/
+uint32_t sceShaccCgGetParameterResourceIndex(
+	SceShaccCgParameter param);
+
+/**	@brief	Returns the buffer index of the parameter.
+
+	Returns the buffer index of the parameter.
+
+	@param[in] param
+		The parameter object.
+
+	@return
+		The buffer index or a value of -1 if no buffer is assigned to this parameter.
+
+	@ingroup shacccg
+*/
+uint32_t sceShaccCgGetParameterBufferIndex(
+	SceShaccCgParameter param);
+
+/**	@brief	Returns true if the parameter is __regformat.
+
+	Returns true if the parameter is __regformat.
+
+	@param[in] param
+		The parameter object.
+
+	@return
+		1 if the value is __regformat, otherwise return 0.
+
+	@ingroup shacccg
+*/
+int32_t sceShaccCgIsParameterRegFormat(
+	SceShaccCgParameter param);
+
+/**	@brief	Returns the first member for a struct parameter.
+
+	Returns the first member for a struct parameter.
+
+	@param[in] param
+		The parameter object.
+
+	@return
+		The parameter object for the first member of a struct or NULL if the parameter was
+		malformed.
+
+	@ingroup shacccg
+*/
+SceShaccCgParameter sceShaccCgGetFirstStructParameter(
+	SceShaccCgParameter param);
+
+/**	@brief	Returns the first member for a uniform block parameter.
+
+	Returns the first member for a uniform block parameter.
+
+	@param[in] param
+		The parameter object.
+
+	@return
+		The parameter object for the first member of a uniform block or NULL if the parameter was
+		malformed.
+
+	@ingroup shacccg
+*/
+SceShaccCgParameter sceShaccCgGetFirstUniformBlockParameter(
+	SceShaccCgParameter param);
+
+/**	@brief	Returns the size of an array.
+
+	Returns the size of an array.
+
+	@param[in] param
+		The parameter object.
+
+	@return
+		The size of an array parameter in terms of the number of elements.
+
+	@ingroup shacccg
+*/
+uint32_t sceShaccCgGetArraySize(
+	SceShaccCgParameter param);
+
+/**	@brief	Returns the parameter for an array element.
+
+	Returns the parameter for an array element.
+
+	@param[in] aparam
+		The array parameter object.
+
+	@param[in] index
+		The array index.
+
+	@return
+		The parameter object for the element associated with the array index.
+
+	@ingroup shacccg
+*/
+SceShaccCgParameter sceShaccCgGetArrayParameter(
+	SceShaccCgParameter aparam,
+	uint32_t index);
+
+/**	@brief	Returns the vector width for a vector parameter.
+
+	Returns the vector width for a vector parameter.
+
+	@param[in] param
+		The vector parameter object.
+
+	@return
+		The width of the vector parameter.
+
+	@ingroup shacccg
+*/
+uint32_t sceShaccCgGetParameterVectorWidth(
+	SceShaccCgParameter param);
+
+/**	@brief	Returns the number of columns for a matrix parameter.
+
+	Returns the number of columns for a matrix parameter.
+
+	@param[in] param
+		The matrix parameter object.
+
+	@return
+		The number of columns for a matrix parameter
+
+	@ingroup shacccg
+*/
+uint32_t sceShaccCgGetParameterColumns(
+	SceShaccCgParameter param);
+
+/**	@brief	Returns the number of rows for a matrix parameter.
+
+	Returns the number of rows for a matrix parameter.
+
+	@param[in] param
+		The matrix parameter object.
+
+	@return
+		The number of rows for a matrix parameter
+
+	@ingroup shacccg
+*/
+uint32_t sceShaccCgGetParameterRows(
+	SceShaccCgParameter param);
+
+/**	@brief	Returns the memory layout for a matrix parameter.
+
+	Returns the memory layout for a matrix parameter.
+
+	@param[in] param
+		The matrix parameter object.
+
+	@return
+		The SceShaccCgParameterMemoryLayout for the matrix parameter.
+
+	@ingroup shacccg
+*/
+SceShaccCgParameterMemoryLayout sceShaccCgGetParameterMemoryLayout(
+	SceShaccCgParameter param);
+
+/**	@brief	Returns the parameter for a row of a matrix parameter.
+
+	Returns the parameter for a row of a matrix parameter.
+
+	@param[in] param
+		The matrix parameter object.
+
+	@param[in] index
+		The row index.
+
+	@return
+		The parameter object for the row paramater.
+
+	@ingroup shacccg
+*/
+SceShaccCgParameter sceShaccCgGetRowParameter(
+	SceShaccCgParameter param,
+	uint32_t index);
+
+/**	@brief	Returns the query format component count for a sampler parameter.
+
+	Returns the query format component count for a sampler parameter.
+
+	@param[in] param
+		The sampler parameter object.
+
+	@return
+		The query format component count.
+
+	@ingroup shacccg
+*/
+uint32_t sceShaccCgGetSamplerQueryFormatWidth(
+	SceShaccCgParameter param);
+
+/**	@brief	Returns the number of different precisions used to as query format for sampler parameter.
+
+	Returns the number of different precisions used to as query format for sampler parameter.
+
+	@param[in] param
+		The sampler parameter object.
+
+	@return
+		count of different precisions used to as query format.
+
+	@ingroup shacccg
+*/
+uint32_t sceShaccCgGetSamplerQueryFormatPrecisionCount(
+	SceShaccCgParameter param);
+
+/**	@brief	Returns query precision format for a sampler parameter.
+
+	Returns query precision format for a sampler parameter.
+
+	@param[in] param
+		The sampler parameter object.
+
+	@param[in] index
+		The index of the precision format.
+
+	@return
+		query precision format.
+
+	@ingroup shacccg
+*/
+SceShaccCgParameterBaseType sceShaccCgGetSamplerQueryFormatPrecision(
+	SceShaccCgParameter param,
+	uint32_t index);
+
+
+#ifdef	__cplusplus
+}
+#endif	/* __cplusplus */
+
+#endif /* _DOLCESDK_PSP2_SHACCCG_PARAMQUERY_H_ */

--- a/shacc_stub/Makefile
+++ b/shacc_stub/Makefile
@@ -1,0 +1,14 @@
+LIBSGEN := $(SDKPREFIX)-libs-gen
+
+all: out/libSceShaccCg_stub.a
+
+out/libSceShaccCg_stub.a: out/Makefile
+	$(MAKE) -C out
+
+out/Makefile:
+	$(LIBSGEN) nids.yml out
+
+clean:
+	$(RM) -r out
+
+.PHONY: clean

--- a/shacc_stub/nids.yml
+++ b/shacc_stub/nids.yml
@@ -1,0 +1,40 @@
+firmware: 3.60
+modules:
+  SceShaccCg:
+    nid: 0xB3B90A35
+    libraries:
+      SceShaccCg:
+        kernel: false
+        nid: 0xA05BBEBB
+        functions:
+          sceShaccCgCompileProgram: 0x66814F35
+          sceShaccCgDestroyCompileOutput: 0xAA82EF0C
+          sceShaccCgGetArrayParameter: 0xBB703EE1
+          sceShaccCgGetArraySize: 0xB4AC9943
+          sceShaccCgGetFirstParameter: 0x17223BEB
+          sceShaccCgGetFirstStructParameter: 0x648739F3
+          sceShaccCgGetFirstUniformBlockParameter: 0x56BFA825
+          sceShaccCgGetNextParameter: 0x46FA0303
+          sceShaccCgGetParameterBaseType: 0x7B2CF324
+          sceShaccCgGetParameterBufferIndex: 0xD4378DB1
+          sceShaccCgGetParameterByName: 0x6FB40CA9
+          sceShaccCgGetParameterClass: 0xDF3DDCFD
+          sceShaccCgGetParameterColumns: 0x7BC25091
+          sceShaccCgGetParameterDirection: 0xDAD4AAE4
+          sceShaccCgGetParameterMemoryLayout: 0xEF8D59D6
+          sceShaccCgGetParameterName: 0x4595A388
+          sceShaccCgGetParameterResourceIndex: 0x6BB58825
+          sceShaccCgGetParameterRows: 0x2654E73A
+          sceShaccCgGetParameterSemantic: 0xA7930FF6
+          sceShaccCgGetParameterUserType: 0x152971B1
+          sceShaccCgGetParameterVariability: 0xF4BAB902
+          sceShaccCgGetParameterVectorWidth: 0x0205DE96
+          sceShaccCgGetRowParameter: 0x07DDFC78
+          sceShaccCgGetSamplerQueryFormatPrecision: 0xA067C481
+          sceShaccCgGetSamplerQueryFormatPrecisionCount: 0x268FAEE9
+          sceShaccCgGetSamplerQueryFormatWidth: 0xA56B1A5B
+          sceShaccCgInitializeCallbackList: 0xA8C2C1C8
+          sceShaccCgInitializeCompileOptions: 0x3B58AFA0
+          sceShaccCgIsParameterReferenced: 0x0E1285A6
+          sceShaccCgIsParameterRegFormat: 0xA13A8A1E
+          sceShaccCgSetDefaultAllocator: 0x6F01D573

--- a/src/essl.c
+++ b/src/essl.c
@@ -254,8 +254,8 @@ inline void EsslParameterListLink(EsslParameterList *parameterList, EsslParamete
     parameterList->totalNameSize += node->nameLength;
 }
 
-int EsslParameterListCreateArray(EsslParameterList *parameterList, SceShaccCgParameter *parameter, EsslParameterType paramType, const char *parentName);
-int EsslParameterListCreateStructure(EsslParameterList *parameterList, SceShaccCgParameter *parameter, EsslParameterType paramType, const char *parentName, int arrayParent)
+int EsslParameterListCreateArray(EsslParameterList *parameterList, SceShaccCgParameter parameter, EsslParameterType paramType, const char *parentName);
+int EsslParameterListCreateStructure(EsslParameterList *parameterList, SceShaccCgParameter parameter, EsslParameterType paramType, const char *parentName, int arrayParent)
 {
     EsslParameterListNode *currentNode = NULL;
     SceShaccCgParameter currentParameter = sceShaccCgGetFirstStructParameter(parameter);
@@ -338,7 +338,7 @@ int EsslParameterListCreateStructure(EsslParameterList *parameterList, SceShaccC
     return 1;
 }
 
-int EsslParameterListCreateArray(EsslParameterList *parameterList, SceShaccCgParameter *parameter, EsslParameterType paramType, const char *parentName)
+int EsslParameterListCreateArray(EsslParameterList *parameterList, SceShaccCgParameter parameter, EsslParameterType paramType, const char *parentName)
 {
     const char *arrayName = sceShaccCgGetParameterName(parameter);
     char *paramName = NULL;
@@ -360,7 +360,7 @@ int EsslParameterListCreateArray(EsslParameterList *parameterList, SceShaccCgPar
             sprintf(paramName, "%s%s", parentName, arrayName);
         }
         else
-            paramName = arrayName;
+            paramName = (char *)arrayName;
 
         while (currentParameter != NULL)
         {
@@ -402,7 +402,7 @@ fail:
     return 0;
 }
 
-int EsslParameterListCreate(EsslParameterList *parameterList, SceShaccCgCompileOutput *compileOutput, EsslParameterType paramType)
+int EsslParameterListCreate(EsslParameterList *parameterList, const SceShaccCgCompileOutput *compileOutput, EsslParameterType paramType)
 {
     SceShaccCgParameterVariability targetVariabiltiy = SCE_SHACCCG_VARIABILITY_INVALID;
     SceShaccCgParameterDirection targetDirection = SCE_SHACCCG_DIRECTION_INVALID;
@@ -538,7 +538,7 @@ void* EsslParameterTableCreate(EsslParameterList *parameterLists, size_t *parame
     return parameterTable;
 }
 
-void EsslCreateBinary(SceShaccCgCompileOutput *compileOutput, void **binary, size_t *binarySize, int vertexShader)
+void EsslCreateBinary(const SceShaccCgCompileOutput *compileOutput, void **binary, size_t *binarySize, int vertexShader)
 {
     EsslHeader header = {"GXPES", 0, 0};
     EsslParameterList parameterLists[3] = {0};

--- a/src/essl.c
+++ b/src/essl.c
@@ -67,43 +67,83 @@ size_t EsslParameterCreate(EsslParameter *parameter, SceShaccCgParameter shaccPa
     switch (parameterClass)
     {
     case SCE_SHACCCG_PARAMETERCLASS_SCALAR:
-        switch (baseType)
+        if (type == ESSL_PARAMETER_TYPE_ATTRIBUTE)
         {
-        case SCE_SHACCCG_BASETYPE_BOOL:
-            parameter->format = ESSL_PARAMETER_FORMAT_BOOL;
-            break;
-        case SCE_SHACCCG_BASETYPE_CHAR:
-        case SCE_SHACCCG_BASETYPE_SHORT:
-        case SCE_SHACCCG_BASETYPE_INT:
-            parameter->format = ESSL_PARAMETER_FORMAT_INT;
-            break;
-        case SCE_SHACCCG_BASETYPE_FIXED:
-        case SCE_SHACCCG_BASETYPE_HALF:
-        case SCE_SHACCCG_BASETYPE_FLOAT:
-            parameter->format = ESSL_PARAMETER_FORMAT_FLOAT;
-            break;
-        default:
-            return 0;
+            switch (baseType)
+            {
+            case SCE_SHACCCG_BASETYPE_BOOL:
+            case SCE_SHACCCG_BASETYPE_CHAR:
+            case SCE_SHACCCG_BASETYPE_SHORT:
+            case SCE_SHACCCG_BASETYPE_INT:
+            case SCE_SHACCCG_BASETYPE_FIXED:
+            case SCE_SHACCCG_BASETYPE_HALF:
+            case SCE_SHACCCG_BASETYPE_FLOAT:
+                parameter->format = ESSL_PARAMETER_FORMAT_FLOAT;
+                break;
+            default:
+                return 0;
+            }
         }
+        else
+        {
+            switch (baseType)
+            {
+            case SCE_SHACCCG_BASETYPE_BOOL:
+                parameter->format = ESSL_PARAMETER_FORMAT_BOOL;
+                break;
+            case SCE_SHACCCG_BASETYPE_CHAR:
+            case SCE_SHACCCG_BASETYPE_SHORT:
+            case SCE_SHACCCG_BASETYPE_INT:
+                parameter->format = ESSL_PARAMETER_FORMAT_INT;
+                break;
+            case SCE_SHACCCG_BASETYPE_FIXED:
+            case SCE_SHACCCG_BASETYPE_HALF:
+            case SCE_SHACCCG_BASETYPE_FLOAT:
+                parameter->format = ESSL_PARAMETER_FORMAT_FLOAT;
+                break;
+            default:
+                return 0;
+            }
+        }    
         break;
     case SCE_SHACCCG_PARAMETERCLASS_VECTOR:
-        switch (baseType)
+        if (type == ESSL_PARAMETER_TYPE_ATTRIBUTE)
         {
-        case SCE_SHACCCG_BASETYPE_BOOL:
-            parameter->format = ESSL_PARAMETER_FORMAT_BOOL + (vectorWidth - 1);
-            break;
-        case SCE_SHACCCG_BASETYPE_CHAR:
-        case SCE_SHACCCG_BASETYPE_SHORT:
-        case SCE_SHACCCG_BASETYPE_INT:
-            parameter->format = ESSL_PARAMETER_FORMAT_INT + (vectorWidth - 1);
-            break;
-        case SCE_SHACCCG_BASETYPE_FIXED:
-        case SCE_SHACCCG_BASETYPE_HALF:
-        case SCE_SHACCCG_BASETYPE_FLOAT:
-            parameter->format = ESSL_PARAMETER_FORMAT_FLOAT + (vectorWidth - 1);
-            break;
-        default:
-            return 0;
+            switch (baseType)
+            {
+            case SCE_SHACCCG_BASETYPE_BOOL:
+            case SCE_SHACCCG_BASETYPE_CHAR:
+            case SCE_SHACCCG_BASETYPE_SHORT:
+            case SCE_SHACCCG_BASETYPE_INT:
+            case SCE_SHACCCG_BASETYPE_FIXED:
+            case SCE_SHACCCG_BASETYPE_HALF:
+            case SCE_SHACCCG_BASETYPE_FLOAT:
+                parameter->format = ESSL_PARAMETER_FORMAT_FLOAT + (vectorWidth - 1);
+                break;
+            default:
+                return 0;
+            }
+        }
+        else
+        {
+            switch (baseType)
+            {
+            case SCE_SHACCCG_BASETYPE_BOOL:
+                parameter->format = ESSL_PARAMETER_FORMAT_BOOL + (vectorWidth - 1);
+                break;
+            case SCE_SHACCCG_BASETYPE_CHAR:
+            case SCE_SHACCCG_BASETYPE_SHORT:
+            case SCE_SHACCCG_BASETYPE_INT:
+                parameter->format = ESSL_PARAMETER_FORMAT_INT + (vectorWidth - 1);
+                break;
+            case SCE_SHACCCG_BASETYPE_FIXED:
+            case SCE_SHACCCG_BASETYPE_HALF:
+            case SCE_SHACCCG_BASETYPE_FLOAT:
+                parameter->format = ESSL_PARAMETER_FORMAT_FLOAT + (vectorWidth - 1);
+                break;
+            default:
+                return 0;
+            }
         }
         break;
     case SCE_SHACCCG_PARAMETERCLASS_MATRIX:

--- a/src/essl.c
+++ b/src/essl.c
@@ -1,0 +1,568 @@
+#include "../include/essl.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#ifdef USE_VITASDK
+#include <psp2/shacccg.h>
+#include "../include/shacccg/paramquery.h"
+#else
+#include <shacccg.h>
+#endif
+
+typedef struct EsslParameterListNode EsslParameterListNode;
+
+typedef struct EsslParameterListNode
+{
+    EsslParameterListNode *next;
+    union 
+    {
+        EsslParameter parameter;
+        EsslVaryingParameter varyingParameter;
+    };
+    size_t nameLength;
+} EsslParameterListNode;
+
+typedef struct EsslParameterList
+{
+    EsslParameterListNode *head;
+    size_t count;
+    size_t totalNameSize;
+} EsslParameterList;
+
+inline size_t EsslParameterSetName(EsslParameter *parameter, SceShaccCgParameter shaccParameter, const char *parentName)
+{
+    const char *paramName = sceShaccCgGetParameterName(shaccParameter);
+
+    // Only the vertex program will encounter this, so make it nice.
+    if ((strcmp(paramName, "main") == 0) && parentName == NULL)
+        paramName = "gl_Position";
+
+    size_t nameLength = strlen(paramName) + 1;
+
+    if (parentName != NULL)
+        nameLength += strlen(parentName);
+
+    parameter->parameterName = calloc(nameLength, sizeof(char));
+    if (parameter->parameterName == NULL)
+        return 0;
+
+    if (parentName)
+        strcat(parameter->parameterName, parentName);
+
+    strcat(parameter->parameterName, paramName);
+
+    return nameLength;
+}
+
+size_t EsslParameterCreate(EsslParameter *parameter, SceShaccCgParameter shaccParameter, EsslParameterType type, size_t elementCount, const char *parentName)
+{
+    size_t columnCount = sceShaccCgGetParameterColumns(shaccParameter);
+    size_t rowCount = sceShaccCgGetParameterRows(shaccParameter);
+    size_t vectorWidth = sceShaccCgGetParameterVectorWidth(shaccParameter);
+
+    SceShaccCgParameterClass parameterClass = sceShaccCgGetParameterClass(shaccParameter);
+    SceShaccCgParameterBaseType baseType = sceShaccCgGetParameterBaseType(shaccParameter);
+    switch (parameterClass)
+    {
+    case SCE_SHACCCG_PARAMETERCLASS_SCALAR:
+        switch (baseType)
+        {
+        case SCE_SHACCCG_BASETYPE_BOOL:
+            parameter->format = ESSL_PARAMETER_FORMAT_BOOL;
+            break;
+        case SCE_SHACCCG_BASETYPE_CHAR:
+        case SCE_SHACCCG_BASETYPE_SHORT:
+        case SCE_SHACCCG_BASETYPE_INT:
+            parameter->format = ESSL_PARAMETER_FORMAT_INT;
+            break;
+        case SCE_SHACCCG_BASETYPE_FIXED:
+        case SCE_SHACCCG_BASETYPE_HALF:
+        case SCE_SHACCCG_BASETYPE_FLOAT:
+            parameter->format = ESSL_PARAMETER_FORMAT_FLOAT;
+            break;
+        default:
+            return 0;
+        }
+        break;
+    case SCE_SHACCCG_PARAMETERCLASS_VECTOR:
+        switch (baseType)
+        {
+        case SCE_SHACCCG_BASETYPE_BOOL:
+            parameter->format = ESSL_PARAMETER_FORMAT_BOOL + (vectorWidth - 1);
+            break;
+        case SCE_SHACCCG_BASETYPE_CHAR:
+        case SCE_SHACCCG_BASETYPE_SHORT:
+        case SCE_SHACCCG_BASETYPE_INT:
+            parameter->format = ESSL_PARAMETER_FORMAT_INT + (vectorWidth - 1);
+            break;
+        case SCE_SHACCCG_BASETYPE_FIXED:
+        case SCE_SHACCCG_BASETYPE_HALF:
+        case SCE_SHACCCG_BASETYPE_FLOAT:
+            parameter->format = ESSL_PARAMETER_FORMAT_FLOAT + (vectorWidth - 1);
+            break;
+        default:
+            return 0;
+        }
+        break;
+    case SCE_SHACCCG_PARAMETERCLASS_MATRIX:
+        if (columnCount == 4 && rowCount == 4)
+            parameter->format = ESSL_PARAMETER_FORMAT_MAT4;
+        else if (columnCount == 3 && rowCount == 3)
+            parameter->format = ESSL_PARAMETER_FORMAT_MAT3;
+        else if (columnCount == 2 && rowCount == 2)
+            parameter->format = ESSL_PARAMETER_FORMAT_MAT2;
+        else
+            return 0;
+        break;
+    case SCE_SHACCCG_PARAMETERCLASS_SAMPLER:
+        switch (baseType)
+        {
+        case SCE_SHACCCG_BASETYPE_SAMPLER1D:
+        case SCE_SHACCCG_BASETYPE_ISAMPLER1D:
+        case SCE_SHACCCG_BASETYPE_USAMPLER1D:
+        case SCE_SHACCCG_BASETYPE_SAMPLER2D:
+        case SCE_SHACCCG_BASETYPE_ISAMPLER2D:
+        case SCE_SHACCCG_BASETYPE_USAMPLER2D:
+            parameter->format = ESSL_PARAMETER_FORMAT_SAMPLER2D;
+            break;
+        case SCE_SHACCCG_BASETYPE_SAMPLERCUBE:
+        case SCE_SHACCCG_BASETYPE_ISAMPLERCUBE:
+        case SCE_SHACCCG_BASETYPE_USAMPLERCUBE:
+            parameter->format = ESSL_PARAMETER_FORMAT_SAMPLERCUBE;
+            break;
+        default:
+            // Unreachable.
+            break;
+        }
+        break;
+    default:
+        // Unreachable.
+        break;
+    }
+
+    parameter->type = type;
+    parameter->elementCount = elementCount;
+    parameter->state = sceShaccCgIsParameterReferenced(shaccParameter);
+
+    if (parameter->type >= ESSL_PARAMETER_TYPE_VARYING_INPUT)
+    {
+        const char *semantic = sceShaccCgGetParameterSemantic(shaccParameter);
+        size_t resourceIndex = sceShaccCgGetParameterResourceIndex(shaccParameter);
+
+        EsslVaryingParameter *varyingParameter = (EsslVaryingParameter *)parameter;
+
+        if (semantic != NULL)
+        {
+            if ((strncmp(semantic, "TEXCOORD", strlen("TEXCOORD")) == 0) || (strncmp(semantic, "TEX", strlen("TEX")) == 0))
+            {
+                varyingParameter->varyingType = ESSL_VARYING_TYPE_TEXCOORD;
+                varyingParameter->resourceIndex = resourceIndex;
+            }
+            else if (strncmp(semantic, "POSITION", strlen("POSITION")) == 0)
+            {
+                varyingParameter->varyingType = ESSL_VARYING_TYPE_POSITION;
+                varyingParameter->resourceIndex = 0;
+            }
+            else if ((strncmp(semantic, "PSIZE", strlen("PSIZE")) == 0) || (strncmp(semantic, "PSIZ", strlen("PSIZ")) == 0))
+            {
+                varyingParameter->varyingType = ESSL_VARYING_TYPE_POINTSIZE;
+                varyingParameter->resourceIndex = 0;
+            }
+            else if (strncmp(semantic, "FACE", strlen("FACE")) == 0)
+            {
+                varyingParameter->varyingType = ESSL_VARYING_TYPE_FRONTFACE;
+                varyingParameter->resourceIndex = 0;
+            }
+            else if (strncmp(semantic, "WPOS", strlen("WPOS")) == 0)
+            {
+                varyingParameter->varyingType = ESSL_VARYING_TYPE_FRAGCOORD;
+                varyingParameter->resourceIndex = 0;
+            }
+            else if ((strncmp(semantic, "SPRITECOORD", strlen("SPRITECOORD")) == 0) || (strncmp(semantic, "POINTCOORD", strlen("POINTCOORD")) == 0))
+            {
+                varyingParameter->varyingType = ESSL_VARYING_TYPE_POINTCOORD;
+                varyingParameter->resourceIndex = 0;
+            }
+            else
+            {
+                varyingParameter->varyingType = -1;
+                varyingParameter->resourceIndex = -1;
+            }
+        }
+        else
+        {
+            varyingParameter->varyingType = -1;
+            varyingParameter->resourceIndex = -1;
+        }
+
+        memset(varyingParameter->padding, 0xFF, 0x24);
+    }
+
+    if (elementCount == 1)
+        return EsslParameterSetName(parameter, shaccParameter, parentName);
+    else
+        return 1;
+}
+
+inline void EsslParameterListLink(EsslParameterList *parameterList, EsslParameterListNode *node)
+{
+    node->next = parameterList->head;
+    parameterList->head = node;
+    parameterList->count++;
+    parameterList->totalNameSize += node->nameLength;
+}
+
+int EsslParameterListCreateArray(EsslParameterList *parameterList, SceShaccCgParameter *parameter, EsslParameterType paramType, const char *parentName);
+int EsslParameterListCreateStructure(EsslParameterList *parameterList, SceShaccCgParameter *parameter, EsslParameterType paramType, const char *parentName, int arrayParent)
+{
+    EsslParameterListNode *currentNode = NULL;
+    SceShaccCgParameter currentParameter = sceShaccCgGetFirstStructParameter(parameter);
+    SceShaccCgParameterClass parameterClass;
+
+    char *paramName;
+    const char *structName = sceShaccCgGetParameterName(parameter);
+
+    if (arrayParent != 0)
+    {
+        paramName = malloc((strlen(parentName) + strlen(structName) + 4) * sizeof(char));
+        if (paramName == NULL)
+            return 0;
+        
+        sprintf(paramName, "%s[%s].", parentName, structName);
+    }
+    else
+    {
+        if (parentName != NULL)
+        {
+            paramName = malloc((strlen(parentName) + strlen(structName) + 2) * sizeof(char));
+            if (paramName == NULL)
+                return 0;
+
+            sprintf(paramName, "%s%s.", parentName, structName);
+        }
+        else
+        {
+            paramName = malloc((strlen(structName) + 2) * sizeof(char));
+            if (paramName == NULL)
+                return 0;
+
+            sprintf(paramName, "%s.", structName);
+        }
+    }
+
+    while (currentParameter != NULL)
+    {
+        parameterClass = sceShaccCgGetParameterClass(currentParameter);
+        switch (parameterClass)
+        {
+        case SCE_SHACCCG_PARAMETERCLASS_STRUCT:
+            if (EsslParameterListCreateStructure(parameterList, currentParameter, paramType, paramName, 0) == 0)
+                goto fail;
+            break;
+        case SCE_SHACCCG_PARAMETERCLASS_ARRAY:
+            if (EsslParameterListCreateArray(parameterList, currentParameter, paramType, paramName) == 0)
+                goto fail;
+            break;
+        case SCE_SHACCCG_PARAMETERCLASS_SCALAR:
+        case SCE_SHACCCG_PARAMETERCLASS_VECTOR:
+        case SCE_SHACCCG_PARAMETERCLASS_MATRIX:
+        case SCE_SHACCCG_PARAMETERCLASS_SAMPLER:
+            currentNode = malloc(sizeof(EsslParameterListNode));
+            if (currentNode == NULL)
+                goto fail;
+
+            currentNode->nameLength = EsslParameterCreate(&currentNode->parameter, currentParameter, paramType, 1, paramName);
+            if (currentNode->nameLength == 0)
+                goto fail;
+
+            EsslParameterListLink(parameterList, currentNode);
+            break;
+        default:
+            break;
+        }
+        
+        currentParameter = sceShaccCgGetNextParameter(currentParameter);
+        continue;
+
+    fail:
+        if (currentNode != NULL)
+            free(currentNode);
+
+        free(paramName);
+        return 0;
+    }
+
+    free(paramName);
+    return 1;
+}
+
+int EsslParameterListCreateArray(EsslParameterList *parameterList, SceShaccCgParameter *parameter, EsslParameterType paramType, const char *parentName)
+{
+    const char *arrayName = sceShaccCgGetParameterName(parameter);
+    char *paramName = NULL;
+
+    EsslParameterListNode *currentNode = NULL;
+    SceShaccCgParameter currentParameter = sceShaccCgGetArrayParameter(parameter, 0);
+    SceShaccCgParameterClass parameterClass;
+
+    parameterClass = sceShaccCgGetParameterClass(currentParameter);
+    switch (parameterClass)
+    {
+    case SCE_SHACCCG_PARAMETERCLASS_STRUCT:
+        if (parentName != NULL)
+        {
+            paramName = malloc((strlen(parentName) + strlen(arrayName) + 1) * sizeof(char));
+            if (paramName == NULL)
+                goto fail;
+            
+            sprintf(paramName, "%s%s", parentName, arrayName);
+        }
+        else
+            paramName = arrayName;
+
+        while (currentParameter != NULL)
+        {
+            if (EsslParameterListCreateStructure(parameterList, currentParameter, paramType, paramName, 1) == 0)
+                goto fail;
+
+            currentParameter = sceShaccCgGetNextParameter(currentParameter);
+        }
+
+        if (paramName != arrayName)
+            free(paramName);
+        break;
+    case SCE_SHACCCG_PARAMETERCLASS_SCALAR:
+    case SCE_SHACCCG_PARAMETERCLASS_VECTOR:
+    case SCE_SHACCCG_PARAMETERCLASS_MATRIX:
+    case SCE_SHACCCG_PARAMETERCLASS_SAMPLER:
+        currentNode = malloc(sizeof(EsslParameterListNode));
+        if (currentNode == NULL)
+            goto fail;
+
+        if (EsslParameterCreate(&currentNode->parameter, currentParameter, paramType, sceShaccCgGetArraySize(parameter), NULL) == 0)
+            goto fail;
+
+        currentNode->nameLength = EsslParameterSetName(&currentNode->parameter, parameter, parentName);
+        if (currentNode->nameLength == 0)
+            goto fail;
+
+        EsslParameterListLink(parameterList, currentNode);
+        break;
+    default:
+        goto fail;
+    }
+
+    return 1;
+fail:
+    if (currentNode != NULL)
+        free(currentNode);
+
+    return 0;
+}
+
+int EsslParameterListCreate(EsslParameterList *parameterList, SceShaccCgCompileOutput *compileOutput, EsslParameterType paramType)
+{
+    SceShaccCgParameterVariability targetVariabiltiy = SCE_SHACCCG_VARIABILITY_INVALID;
+    SceShaccCgParameterDirection targetDirection = SCE_SHACCCG_DIRECTION_INVALID;
+
+    switch (paramType)
+    {
+    case ESSL_PARAMETER_TYPE_ATTRIBUTE:
+        targetVariabiltiy = SCE_SHACCCG_VARIABILITY_VARYING;
+        targetDirection = SCE_SHACCCG_DIRECTION_IN;
+        break;
+    case ESSL_PARAMETER_TYPE_UNIFORM:
+        targetVariabiltiy = SCE_SHACCCG_VARIABILITY_UNIFORM;
+        targetDirection = SCE_SHACCCG_DIRECTION_IN;
+        break;
+    case ESSL_PARAMETER_TYPE_VARYING_INPUT:
+        targetVariabiltiy = SCE_SHACCCG_VARIABILITY_VARYING;
+        targetDirection = SCE_SHACCCG_DIRECTION_IN;
+        break;
+    case ESSL_PARAMETER_TYPE_VARYING_OUTPUT:
+        targetVariabiltiy = SCE_SHACCCG_VARIABILITY_VARYING;
+        targetDirection = SCE_SHACCCG_DIRECTION_OUT;
+        break;
+    }
+
+    EsslParameterListNode *currentNode = NULL;
+    SceShaccCgParameter currentParameter = sceShaccCgGetFirstParameter(compileOutput);
+    SceShaccCgParameterClass parameterClass = SCE_SHACCCG_PARAMETERCLASS_INVALID;
+
+    while (currentParameter != NULL)
+    {
+        if ((sceShaccCgGetParameterDirection(currentParameter) != targetDirection) || (sceShaccCgGetParameterVariability(currentParameter) != targetVariabiltiy))
+            goto next;
+
+        parameterClass = sceShaccCgGetParameterClass(currentParameter);
+        switch (parameterClass)
+        {
+        case SCE_SHACCCG_PARAMETERCLASS_STRUCT:
+            if (EsslParameterListCreateStructure(parameterList, currentParameter, paramType, NULL, 0) == 0)
+                goto fail;
+            break;
+        case SCE_SHACCCG_PARAMETERCLASS_ARRAY:
+            if (EsslParameterListCreateArray(parameterList, currentParameter, paramType, NULL) == 0)
+                goto fail;
+            break;
+        case SCE_SHACCCG_PARAMETERCLASS_SCALAR:
+        case SCE_SHACCCG_PARAMETERCLASS_VECTOR:
+        case SCE_SHACCCG_PARAMETERCLASS_MATRIX:
+        case SCE_SHACCCG_PARAMETERCLASS_SAMPLER:
+            currentNode = malloc(sizeof(EsslParameterListNode));
+            if (currentNode == NULL)
+                goto fail;
+
+            currentNode->nameLength = EsslParameterCreate(&currentNode->parameter, currentParameter, paramType, 1, NULL);
+            if (currentNode->nameLength == 0)
+                goto fail;
+
+            EsslParameterListLink(parameterList, currentNode);
+            break;
+        default:
+            break;
+        }
+
+    next:
+        currentParameter = sceShaccCgGetNextParameter(currentParameter);
+        continue;
+
+    fail:
+        if (currentNode != NULL)
+            free(currentNode);
+
+        return 0;
+    }
+
+    return 1;
+}
+
+void* EsslParameterTableCreate(EsslParameterList *parameterLists, size_t *parameterTableSize)
+{
+    uint8_t *parameterTable;
+    *parameterTableSize = sizeof(uint32_t) * 3;
+    uint8_t *curPtr;
+
+    char *namePtr;
+    uint32_t nameOffset;
+
+    *parameterTableSize += sizeof(EsslParameter) * parameterLists[0].count;
+    *parameterTableSize += sizeof(EsslParameter) * parameterLists[1].count;
+    *parameterTableSize += sizeof(EsslVaryingParameter) * parameterLists[2].count;
+    nameOffset = *parameterTableSize;
+
+    *parameterTableSize += parameterLists[0].totalNameSize;
+    *parameterTableSize += parameterLists[1].totalNameSize;
+    *parameterTableSize += parameterLists[2].totalNameSize;
+
+    if (*parameterTableSize == sizeof(uint32_t) * 3)
+        return NULL;
+
+    parameterTable = malloc(*parameterTableSize);
+    if (parameterTable == NULL)
+        return NULL;
+
+    curPtr = parameterTable;
+    namePtr = parameterTable + nameOffset;
+
+    for (int i = 2; i >= 0; i--)
+    {
+        *(uint32_t *)curPtr = parameterLists[i].count;
+        curPtr += 4;
+
+        EsslParameterListNode *node = parameterLists[i].head;
+        while (node != NULL)
+        {
+            size_t parameterSize = node->parameter.type > 1 ? sizeof(EsslVaryingParameter) : sizeof(EsslParameter);
+            memcpy(curPtr, &node->varyingParameter.header, parameterSize);
+
+            char *paramName = node->parameter.parameterName;
+            size_t nameLength = strlen(paramName) + 1;
+            strcpy(namePtr, paramName);
+
+            ((EsslParameter *)curPtr)->parameterNameOffset = (uint32_t)namePtr - (uint32_t)curPtr;
+
+            namePtr += nameLength;
+            curPtr += parameterSize;
+
+            EsslParameterListNode *prevNode = node;
+            node = node->next;
+
+            free(prevNode->parameter.parameterName);
+            free(prevNode);
+        }
+    }
+
+    return parameterTable;
+}
+
+void EsslCreateBinary(SceShaccCgCompileOutput *compileOutput, void **binary, size_t *binarySize, int vertexShader)
+{
+    EsslHeader header = {"GXPES", 0, 0};
+    EsslParameterList parameterLists[3] = {0};
+    void *parameterTable = NULL;
+    size_t parameterTableSize = 0;
+
+    for (int i = 2; i >= 0; i--)
+    {
+        if (!vertexShader && i == 0)
+            break;
+
+        EsslParameterType type = i;
+        
+        if (vertexShader && type == ESSL_PARAMETER_TYPE_VARYING_INPUT)
+            type = ESSL_PARAMETER_TYPE_VARYING_OUTPUT;
+        
+        // Don't attempt to process attributes for fragment shader.
+        if (vertexShader == 0 && i == 0)
+            break;
+
+        if (EsslParameterListCreate(&parameterLists[i], compileOutput, type) == 0)
+            goto error;
+    }
+
+    parameterTable = EsslParameterTableCreate(parameterLists, &parameterTableSize);
+    if (parameterTable == NULL)
+        goto error;
+
+    *binarySize = (compileOutput->programSize + 0xB) + parameterTableSize;
+    *binary = malloc(*binarySize);
+    if (*binary == NULL)
+        goto error;
+
+    memcpy(*binary + 0xB, compileOutput->programData, compileOutput->programSize);
+
+    header.parameterTableSize = parameterTableSize;
+    header.parameterTableOffset = *binarySize - parameterTableSize;
+
+    memcpy(*binary, &header, sizeof(EsslHeader));
+    memcpy(*binary + header.parameterTableOffset, parameterTable, parameterTableSize);
+
+    return;
+error:
+    *binary = malloc(compileOutput->programSize);
+    memcpy(*binary, compileOutput->programData, compileOutput->programSize);
+    *binarySize = compileOutput->programSize;
+
+    for (int i = 0; i < 2; i++)
+    {
+        EsslParameterListNode *node = parameterLists[i].head;
+        while (node != NULL)
+        {
+            if (node->parameter.parameterName)
+                free(node->parameter.parameterName);
+
+            EsslParameterListNode *prevNode = node;
+            node = node->next;
+
+            free(prevNode);
+        }
+    }
+
+    if (parameterTable != NULL)
+        free(parameterTable);
+
+    return;
+}

--- a/src/essl.c
+++ b/src/essl.c
@@ -152,9 +152,6 @@ size_t EsslParameterCreate(EsslParameter *parameter, SceShaccCgParameter shaccPa
     case SCE_SHACCCG_PARAMETERCLASS_SAMPLER:
         switch (baseType)
         {
-        case SCE_SHACCCG_BASETYPE_SAMPLER1D:
-        case SCE_SHACCCG_BASETYPE_ISAMPLER1D:
-        case SCE_SHACCCG_BASETYPE_USAMPLER1D:
         case SCE_SHACCCG_BASETYPE_SAMPLER2D:
         case SCE_SHACCCG_BASETYPE_ISAMPLER2D:
         case SCE_SHACCCG_BASETYPE_USAMPLER2D:
@@ -166,7 +163,7 @@ size_t EsslParameterCreate(EsslParameter *parameter, SceShaccCgParameter shaccPa
             parameter->format = ESSL_PARAMETER_FORMAT_SAMPLERCUBE;
             break;
         default:
-            // Unreachable.
+            return 0;
             break;
         }
         break;

--- a/src/patches.c
+++ b/src/patches.c
@@ -246,22 +246,22 @@ SceGxmErrorCode sceGxmBeginScene_loadPatch(SceGxmContext *context, unsigned int 
     case SCE_GXM_DEPTH_STENCIL_FORMAT_DF32M:
     case SCE_GXM_DEPTH_STENCIL_FORMAT_D16:
         if (clearDepth)
-            sceGxmDepthStencilSurfaceSetForceLoadMode(depthStencil, SCE_GXM_DEPTH_STENCIL_FORCE_LOAD_DISABLED);
+            sceGxmDepthStencilSurfaceSetForceLoadMode((SceGxmDepthStencilSurface *)depthStencil, SCE_GXM_DEPTH_STENCIL_FORCE_LOAD_DISABLED);
         break;
     case SCE_GXM_DEPTH_STENCIL_FORMAT_DF32M_S8:
     case SCE_GXM_DEPTH_STENCIL_FORMAT_S8D24:
         if (clearDepth && clearStencil)
-            sceGxmDepthStencilSurfaceSetForceLoadMode(depthStencil, SCE_GXM_DEPTH_STENCIL_FORCE_LOAD_DISABLED);
+            sceGxmDepthStencilSurfaceSetForceLoadMode((SceGxmDepthStencilSurface *)depthStencil, SCE_GXM_DEPTH_STENCIL_FORCE_LOAD_DISABLED);
         break;
     case SCE_GXM_DEPTH_STENCIL_FORMAT_S8:
         if (clearStencil)
-            sceGxmDepthStencilSurfaceSetForceLoadMode(depthStencil, SCE_GXM_DEPTH_STENCIL_FORCE_LOAD_DISABLED);
+            sceGxmDepthStencilSurfaceSetForceLoadMode((SceGxmDepthStencilSurface *)depthStencil, SCE_GXM_DEPTH_STENCIL_FORCE_LOAD_DISABLED);
         break;
     }
 
     int ret = TAI_CONTINUE(SceGxmErrorCode, hookRef[21], context, flags, renderTarget, validRegion, vertexSyncObject, fragmentSyncObject, colorSurface, depthStencil);
 
-    sceGxmDepthStencilSurfaceSetForceLoadMode(depthStencil, SCE_GXM_DEPTH_STENCIL_FORCE_LOAD_ENABLED);
+    sceGxmDepthStencilSurfaceSetForceLoadMode((SceGxmDepthStencilSurface *)depthStencil, SCE_GXM_DEPTH_STENCIL_FORCE_LOAD_ENABLED);
 
     return ret;
 }

--- a/src/shacccgpatch.c
+++ b/src/shacccgpatch.c
@@ -30,6 +30,7 @@
 #include <shacccg.h>
 #endif
 #include "../include/debug.h"
+#include "../include/essl.h"
 
 static SceShaccCgSourceFile source;
 static const SceShaccCgCompileOutput *output = NULL;
@@ -127,10 +128,12 @@ int pglPlatformShaderCompiler_CustomPatch(int a1, void *shader)
 
     if (output->programData)
     {
-        SceUInt8 *shaderData = malloc(output->programSize);
-        memcpy(shaderData, output->programData, output->programSize);
+        SceUInt8 *shaderData;
+        uint32_t shaderDataSize;
+        EsslCreateBinary(output, &shaderData, &shaderDataSize, *(uint32_t *)(shader + 0x1C) == 1);
+        
         *(SceUInt8**)(shader + 0x34) = shaderData;   // Compiled Shader Data Pointer
-        *(SceInt32*)(shader + 0x38) = output->programSize;  // Compiled Shader Data Size Pointer
+        *(SceInt32*)(shader + 0x38) = shaderDataSize;  // Compiled Shader Data Size Pointer
         *(int*)(&shader + 0x30) = 1;    // Flags Indicating Successful Compile
         *(int*)(&shader + 0x1d) = 2;
 


### PR DESCRIPTION
The generation of the GXPES binary will fail if any uniform or attribute parameter functionality from Cg which isn't supported or allowed by Piglet or the GLSL ES 1.0 feature set is used. For example, constant/uniform buffers or multi-dimensional arrays.